### PR TITLE
Add script to sort unlabeled files by detected type and date

### DIFF
--- a/sort_unlabeled.sh
+++ b/sort_unlabeled.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: sort_unlabeled.sh <input_dir> <output_dir>
+
+Sort files without extensions by detecting MIME type and organizing them into
+category/date folders with SHA256 filenames. Files are hardlinked into the
+output directory.
+USAGE
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+    exit 1
+fi
+
+INPUT_DIR="${1%/}"
+OUTPUT_DIR="${2%/}"
+
+if [[ ! -d "$INPUT_DIR" ]]; then
+    echo "Error: input directory does not exist: $INPUT_DIR" >&2
+    exit 1
+fi
+
+if ! command -v file >/dev/null 2>&1; then
+    echo "Error: 'file' command not found." >&2
+    exit 1
+fi
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "Error: 'sha256sum' command not found." >&2
+    exit 1
+fi
+
+if ! command -v stat >/dev/null 2>&1; then
+    echo "Error: 'stat' command not found." >&2
+    exit 1
+fi
+
+get_year_month_from_exif() {
+    local file="$1"
+    if ! command -v exiftool >/dev/null 2>&1; then
+        return 1
+    fi
+
+    local exif_date
+    exif_date=$(exiftool -s -s -s \
+        -DateTimeOriginal \
+        -CreateDate \
+        -MediaCreateDate \
+        -d "%Y-%m" \
+        -- "$file" 2>/dev/null | head -n 1 || true)
+
+    if [[ "$exif_date" =~ ^[0-9]{4}-[0-9]{2}$ ]]; then
+        printf '%s' "$exif_date"
+        return 0
+    fi
+
+    return 1
+}
+
+get_year_month_from_stat() {
+    local file="$1"
+    local timestamp
+    timestamp=$(stat -c %W -- "$file" 2>/dev/null || echo 0)
+    if [[ "$timestamp" == "0" || "$timestamp" == "-1" ]]; then
+        timestamp=$(stat -c %Y -- "$file")
+    fi
+    date -d "@$timestamp" "+%Y-%m"
+}
+
+get_extension_and_category() {
+    local file="$1"
+    local mime
+    local desc
+
+    mime=$(file --mime-type -b -- "$file")
+    desc=$(file -b -- "$file")
+
+    case "$mime" in
+        image/jpeg)
+            echo "jpg images"; return 0 ;;
+        image/png)
+            echo "png images"; return 0 ;;
+        image/gif)
+            echo "gif images"; return 0 ;;
+        image/webp)
+            echo "webp images"; return 0 ;;
+        image/tiff)
+            echo "tif images"; return 0 ;;
+        image/heic)
+            echo "heic images"; return 0 ;;
+        image/heif)
+            echo "heif images"; return 0 ;;
+        video/mp4)
+            echo "mp4 videos"; return 0 ;;
+        video/quicktime)
+            echo "mov videos"; return 0 ;;
+        video/x-msvideo)
+            echo "avi videos"; return 0 ;;
+        video/x-matroska)
+            echo "mkv videos"; return 0 ;;
+        audio/mpeg)
+            echo "mp3 audio"; return 0 ;;
+        audio/x-wav)
+            echo "wav audio"; return 0 ;;
+        audio/flac)
+            echo "flac audio"; return 0 ;;
+        audio/aac)
+            echo "aac audio"; return 0 ;;
+        application/pdf)
+            echo "pdf documents"; return 0 ;;
+        application/msword)
+            echo "doc documents"; return 0 ;;
+        application/vnd.openxmlformats-officedocument.wordprocessingml.document)
+            echo "docx documents"; return 0 ;;
+        application/vnd.ms-excel)
+            echo "xls documents"; return 0 ;;
+        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)
+            echo "xlsx documents"; return 0 ;;
+        application/vnd.ms-powerpoint)
+            echo "ppt documents"; return 0 ;;
+        application/vnd.openxmlformats-officedocument.presentationml.presentation)
+            echo "pptx documents"; return 0 ;;
+        text/plain)
+            echo "txt text"; return 0 ;;
+        text/csv)
+            echo "csv text"; return 0 ;;
+        application/json|text/json)
+            echo "json text"; return 0 ;;
+        application/zip)
+            echo "zip archives"; return 0 ;;
+        application/x-7z-compressed)
+            echo "7z archives"; return 0 ;;
+        application/x-rar)
+            echo "rar archives"; return 0 ;;
+        application/x-tar)
+            echo "tar archives"; return 0 ;;
+        application/gzip)
+            echo "gz archives"; return 0 ;;
+        application/x-bzip2)
+            echo "bz2 archives"; return 0 ;;
+        application/x-xz)
+            echo "xz archives"; return 0 ;;
+        application/x-executable|application/x-pie-executable|application/x-sharedlib|application/x-msdownload)
+            echo "exe executables"; return 0 ;;
+    esac
+
+    if [[ "$desc" == *"tar archive"* && "$mime" == "application/gzip" ]]; then
+        echo "tar.gz archives"; return 0
+    fi
+
+    echo "bin unknown"
+}
+
+process_file() {
+    local file="$1"
+    local ext_category
+    local extension
+    local category
+    local year_month
+    local hash
+    local target_dir
+    local target_file
+
+    ext_category=$(get_extension_and_category "$file")
+    extension=${ext_category%% *}
+    category=${ext_category##* }
+
+    if ! year_month=$(get_year_month_from_exif "$file"); then
+        year_month=$(get_year_month_from_stat "$file")
+    fi
+
+    hash=$(sha256sum -- "$file" | awk '{print toupper($1)}')
+
+    extension=$(printf '%s' "$extension" | tr '[:upper:]' '[:lower:]')
+
+    target_dir="$OUTPUT_DIR/$category/$year_month"
+    mkdir -p "$target_dir"
+
+    target_file="$target_dir/$hash.$extension"
+
+    if [[ -e "$target_file" ]]; then
+        return 0
+    fi
+
+    ln -- "$file" "$target_file"
+}
+
+find_cmd=(find "$INPUT_DIR" -type f)
+if [[ "$OUTPUT_DIR" == "$INPUT_DIR" || "$OUTPUT_DIR" == "$INPUT_DIR"/* ]]; then
+    find_cmd+=( -not -path "$OUTPUT_DIR/*" )
+fi
+
+while IFS= read -r -d '' file; do
+    process_file "$file"
+done < <("${find_cmd[@]}" -print0)


### PR DESCRIPTION
### Motivation
- Provide a focused tool to process files without extensions by detecting content type, normalizing extensions, and organizing into category/date folders using robust metadata when available.
- Ensure deterministic, collision-safe filenames by using uppercase SHA256 checksums and create hardlinks in the sorted layout to avoid duplicating data.

### Description
- Add `sort_unlabeled.sh`, a standalone executable script that accepts `input_dir` and `output_dir` and recursively finds files to process using `find` while excluding the output path.
- Detect file type with `file --mime-type` (and descriptive fallback), map MIME types to normalized lower-case extensions and categories, and treat unknowns as `bin unknown`.
- Derive folder date as `YYYY-MM` using `exiftool` (`DateTimeOriginal`, `CreateDate`, `MediaCreateDate`) when available and fall back to file birth/modify timestamps via `stat` when EXIF is absent or invalid.
- Compute file SHA256 with `sha256sum`, convert the hex digest to uppercase for filenames, create destination directory `OUTPUT_DIR/<category>/<YYYY-MM>`, and create a hardlink `ln` to `OUTPUT_DIR/<category>/<YYYY-MM>/<SHA256>.<ext>` if a target does not already exist.

### Testing
- No automated tests were executed for this change (script-only addition).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697846a0c7c083278ad67c0bc09e8765)