### PR TITLE
Improve timestamp portability and hardlink resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ deduplicated output structure. The output layout is:
 
 The script expects these commands to be available:
 
-- `file`, `sha256sum`, `stat`, `date` (usually from coreutils)
+- `file`, `sha256sum`, `stat`, `date` (GNU coreutils; on macOS install
+  `coreutils` to get `gdate` for GNU-style `date -d`)
 
 Optional:
 


### PR DESCRIPTION
### Motivation
- Make timestamp-to-YYYY-MM conversion portable across environments (GNU `date`, `gdate`, BSD `date`) so the script works on macOS and Linux.
- Avoid the script failing when `stat` cannot provide a birth time by falling back to other timestamp sources.
- Prevent the whole run from aborting if a hardlink operation fails and make directory creation more robust for edge-case names.

### Description
- Add `format_timestamp()` to produce `YYYY-MM` from a POSIX timestamp using `gdate`, GNU `date -d`, or BSD `date -r` as available, and call it from `get_year_month_from_stat()`.
- Make `get_year_month_from_stat()` fall back from `stat -c %W` to `stat -c %Y` and finally to `date +%s` if needed before formatting.
- Use `mkdir -p --` when creating target directories to safely handle directory names beginning with `-`.
- Wrap `ln` in an `if ! ...; then` block so failures emit a warning and the script continues instead of exiting.
- Update `README.md` to clarify that GNU coreutils (or `gdate` on macOS) are recommended for proper `date -d` behavior and fix the usage text to `YYYY-MM`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784cb76ba88327b88617b5c3db1b95)