### PR TITLE
Prepare release-ready script: add version/help flags and improve portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ deduplicated output structure. The output layout is:
 
 The script expects these commands to be available:
 
-- `file`, `sha256sum`, `stat`, `date` (GNU coreutils; on macOS install
-  `coreutils` to get `gdate` for GNU-style `date -d`)
+- `file`, `sha256sum`, `stat`/`gstat`, `date` (GNU coreutils; on macOS install
+  `coreutils` to get `gdate` and `gstat` for GNU-style flags)
 
 Optional:
 
@@ -36,6 +36,10 @@ Optional:
 
 ```bash
 ./organize_and_dedup.sh <input_dir> <output_dir>
+```
+
+```bash
+./organize_and_dedup.sh --version
 ```
 
 ### Example


### PR DESCRIPTION
### Motivation
- Make the script release-ready by exposing a version flag and user-friendly help output. 
- Improve portability across GNU/BSD environments for timestamp extraction. 
- Harden MIME detection so the script degrades gracefully when `file` cannot identify a type.

### Description
- Added `VERSION` and support for `-h|--help` and `-v|--version` to `organize_and_dedup.sh` and updated `usage()` to document the options. 
- Implemented `STAT_CMD` detection to prefer `gstat` when available and added a `get_stat_timestamp()` helper to choose GNU `-c` or BSD `-f` flags so `get_year_month_from_stat()` works across platforms. 
- Made `file` calls tolerant to errors by redirecting stderr and returning a warning plus `bin unknown` when MIME detection fails. 
- Updated `README.md` to document `stat`/`gstat` requirement and the new `--version` usage example.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784f12305c8327a1902e232665ed10)