### PR TITLE
Add bats test suite, test data generator, and real CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,42 +6,43 @@ on:
     branches: ["main", "master"]
 
 jobs:
-  basic-checks:
+  bash-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node (if needed)
-        if: ${{ hashFiles('package.json') != '' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install deps (Node)
-        if: ${{ hashFiles('package.json') != '' }}
-        run: npm ci
-
-      - name: Test (Node)
-        if: ${{ hashFiles('package.json') != '' }}
-        run: npm test --if-present
-
-      - name: Setup Python (if needed)
-        if: ${{ hashFiles('requirements.txt', 'pyproject.toml') != '' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install deps (Python)
-        if: ${{ hashFiles('requirements.txt') != '' }}
-        run: pip install -r requirements.txt
-
-      - name: Test (Python)
-        if: ${{ hashFiles('tests/**/*.py', '*test*.py') != '' }}
+      - name: Install bats
         run: |
-          python -m pip install pytest || true
-          pytest -q || true
+          sudo apt-get update
+          sudo apt-get install -y bats
 
-      - name: Repo hygiene
+      - name: Install exiftool (optional dependency)
+        run: sudo apt-get install -y libimage-exiftool-perl
+
+      - name: Verify required tools
         run: |
-          echo "CI baseline checks completed"
+          echo "bash: $(bash --version | head -1)"
+          echo "file: $(file --version | head -1)"
+          echo "sha256sum: $(sha256sum --version | head -1)"
+          echo "stat: $(stat --version | head -1)"
+          echo "bats: $(bats --version)"
+          which exiftool && exiftool -ver || echo "exiftool: not installed"
+
+      - name: Run test data generator
+        run: |
+          python3 tests/generate_test_data.py /tmp/test_input --count 80 --seed 42
+
+      - name: Run script against generated data
+        run: |
+          bash organize_and_dedup.sh /tmp/test_input /tmp/test_output
+          echo "---"
+          echo "Output structure:"
+          find /tmp/test_output -type d | sort
+          echo "---"
+          echo "Files per category:"
+          for d in /tmp/test_output/*/; do
+            echo "  $(basename "$d"): $(find "$d" -type f | wc -l) files"
+          done
+
+      - name: Run bats test suite
+        run: bats tests/

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Generate test data for organize_and_dedup.sh.
+
+Creates a directory tree with realistic files covering the edge cases
+identified in GitHub issues #15-#52.
+
+Usage:
+    python3 tests/generate_test_data.py /tmp/test_input [--count N] [--seed S]
+
+Covered scenarios:
+  - 19 file types with valid MIME headers (images, audio, video, docs, code, text, archives, fonts, db)
+  - Duplicate files (same content, different names) → dedup test
+  - Wrong extension files → MIME detection test (#37)
+  - No-extension files → fallback test
+  - Empty files → edge case (#35)
+  - tar.gz misnamed as .gz → issue #34
+  - Plain .gz named as .tar.gz → false positive check
+  - Unicode filenames, spaces, special chars ( ) & +
+  - Very long filename (200+ chars)
+  - Identical content different extensions (.txt vs .csv)
+  - 5 exact duplicate JPEGs → dedup stress test
+  - Random nesting depth (0-4 levels)
+  - Random dates (2015-2026) via mtime + EXIF (if exiftool installed)
+"""
+
+import argparse
+import gzip
+import io
+import json
+import os
+import random
+import shutil
+import sqlite3
+import struct
+import subprocess
+import sys
+import tarfile
+import time
+import zipfile
+import zlib
+from pathlib import Path
+
+
+# --- Minimal valid file generators (so `file --mime-type` detects correctly) ---
+
+def make_jpeg(path, width=100, height=100):
+    with open(path, "wb") as f:
+        f.write(b"\xff\xd8")  # SOI
+        f.write(b"\xff\xe0")  # APP0
+        f.write(struct.pack(">H", 16))
+        f.write(b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00")
+        f.write(b"\xff\xc0")  # SOF0
+        f.write(struct.pack(">H", 11))
+        f.write(b"\x08")
+        f.write(struct.pack(">HH", height, width))
+        f.write(b"\x03\x01\x22\x00")
+        f.write(b"\xff\xda")  # SOS
+        f.write(struct.pack(">H", 8))
+        f.write(b"\x03\x01\x22\x00\x3f\x00")
+        f.write(b"\x00" * 10)
+        f.write(b"\xff\xd9")  # EOI
+
+
+def make_png(path, width=100, height=100):
+    with open(path, "wb") as f:
+        f.write(b"\x89PNG\r\n\x1a\n")
+        ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+        chunk = b"IHDR" + ihdr
+        f.write(struct.pack(">I", len(ihdr)))
+        f.write(chunk)
+        f.write(struct.pack(">I", zlib.crc32(chunk) & 0xffffffff))
+        raw = b"\x00" + b"\x00" * (width * 3)
+        compressed = zlib.compress(raw * height)
+        chunk = b"IDAT" + compressed
+        f.write(struct.pack(">I", len(compressed)))
+        f.write(chunk)
+        f.write(struct.pack(">I", zlib.crc32(chunk) & 0xffffffff))
+        chunk = b"IEND"
+        f.write(struct.pack(">I", 0))
+        f.write(chunk)
+        f.write(struct.pack(">I", zlib.crc32(chunk) & 0xffffffff))
+
+
+def make_gif(path, width=100, height=100):
+    with open(path, "wb") as f:
+        f.write(b"GIF89a")
+        f.write(struct.pack("<HH", width, height))
+        f.write(b"\x80\x00\x00")
+        f.write(b"\x00\x00\x00\xff\xff\xff")
+        f.write(b"\x2c")
+        f.write(struct.pack("<HHHH", 0, 0, width, height))
+        f.write(b"\x00")
+        f.write(b"\x02\x02\x4c\x01\x00")
+        f.write(b"\x00")
+        f.write(b"\x3b")
+
+
+def make_pdf(path):
+    content = (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+        b"xref\n0 4\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n190\n%%EOF"
+    )
+    with open(path, "wb") as f:
+        f.write(content)
+
+
+def make_mp3(path, duration_sec=1):
+    with open(path, "wb") as f:
+        header = b"\xff\xfb\x90\x64"
+        frame_size = 417
+        for _ in range(max(1, duration_sec * 38)):
+            f.write(header)
+            f.write(b"\x00" * (frame_size - 4))
+
+
+def make_wav(path, duration_sec=1):
+    sample_rate = 8000
+    num_samples = sample_rate * duration_sec
+    data = b"\x00\x00" * num_samples
+    with open(path, "wb") as f:
+        f.write(b"RIFF")
+        f.write(struct.pack("<I", 36 + len(data)))
+        f.write(b"WAVE")
+        f.write(b"fmt ")
+        f.write(struct.pack("<IHHIIHH", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16))
+        f.write(b"data")
+        f.write(struct.pack("<I", len(data)))
+        f.write(data)
+
+
+def make_mp4(path, duration_sec=1):
+    buf = io.BytesIO()
+
+    def write_box(buf, box_type, data):
+        buf.write(struct.pack(">I", 8 + len(data)))
+        buf.write(box_type)
+        buf.write(data)
+
+    ftyp = b"isom\x00\x00\x02\x00isomiso2avc1mp41"
+    write_box(buf, b"ftyp", ftyp)
+    mvhd = struct.pack(">I", 0) * 4 + b"\x00" * 80
+    write_box(buf, b"moov", mvhd)
+    with open(path, "wb") as f:
+        f.write(buf.getvalue())
+
+
+def make_zip(path):
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("test.txt", "test content")
+        z.writestr("nested/data.json", '{"key": "value"}')
+
+
+def make_targz(path):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="test.txt")
+        info.size = 12
+        tar.addfile(info, io.BytesIO(b"test content"))
+    with open(path, "wb") as f:
+        f.write(buf.getvalue())
+
+
+def make_gz(path):
+    with gzip.open(path, "wb") as f:
+        f.write(b"just gzipped text, not a tar")
+
+
+def make_json(path):
+    with open(path, "w") as f:
+        json.dump({"name": "test", "value": 42, "items": [1, 2, 3]}, f, indent=2)
+
+
+def make_csv(path):
+    with open(path, "w") as f:
+        f.write("name,age,city\nAlice,30,Sydney\nBob,25,Melbourne\n")
+
+
+def make_html(path):
+    with open(path, "w") as f:
+        f.write("<!DOCTYPE html>\n<html><head><title>Test</title></head>")
+        f.write("<body><h1>Hello</h1></body></html>\n")
+
+
+def make_xml(path):
+    with open(path, "w") as f:
+        f.write('<?xml version="1.0"?>\n<root><item>test</item></root>')
+
+
+def make_python(path):
+    with open(path, "w") as f:
+        f.write("#!/usr/bin/env python3\n")
+        f.write("def hello():\n    print('Hello, World!')\n")
+        f.write("if __name__ == '__main__':\n    hello()\n")
+
+
+def make_bash(path):
+    with open(path, "w") as f:
+        f.write("#!/bin/bash\necho 'Hello from bash'\n")
+        f.write("for i in 1 2 3; do\n  echo $i\ndone\n")
+
+
+def make_text(path):
+    with open(path, "w") as f:
+        f.write("This is a plain text file.\nLine 2 here.\n")
+
+
+def make_ttf(path):
+    tables = {
+        b"head": b"\x00\x01\x00\x00" + b"\x00" * 54,
+        b"cmap": b"\x00\x00\x00\x00" + b"\x00" * 4,
+        b"glyf": b"\x00" * 10,
+        b"loca": b"\x00\x00\x00\x00",
+        b"maxp": b"\x00\x00\x50\x00" + b"\x00" * 28,
+    }
+    num_tables = len(tables)
+    header_size = 12 + num_tables * 16
+    offset = header_size
+    table_entries = []
+    table_data = b""
+    for tag, data in tables.items():
+        table_entries.append((tag, 0, offset, len(data)))
+        padded = data + b"\x00" * ((4 - len(data) % 4) % 4)
+        table_data += padded
+        offset += len(padded)
+    with open(path, "wb") as f:
+        f.write(struct.pack(">IHhHH", 0x00010000, num_tables, 256, 8, 1))
+        for tag, checksum, off, length in table_entries:
+            f.write(tag + struct.pack(">III", checksum, off, length))
+        f.write(table_data)
+
+
+def make_sqlite(path):
+    conn = sqlite3.connect(path)
+    c = conn.cursor()
+    c.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
+    c.execute("INSERT INTO test (name) VALUES ('Alice'), ('Bob')")
+    conn.commit()
+    conn.close()
+
+
+def make_empty(path):
+    open(path, "w").close()
+
+
+def make_js(path):
+    with open(path, "w") as f:
+        f.write("console.log('hello world');\n")
+
+
+def make_c(path):
+    with open(path, "w") as f:
+        f.write('#include <stdio.h>\nint main() { printf("hello\\n"); return 0; }\n')
+
+
+GENERATORS = {
+    "jpg": make_jpeg,
+    "png": make_png,
+    "gif": make_gif,
+    "pdf": make_pdf,
+    "mp3": make_mp3,
+    "wav": make_wav,
+    "mp4": make_mp4,
+    "zip": make_zip,
+    "tar.gz": make_targz,
+    "gz": make_gz,
+    "json": make_json,
+    "csv": make_csv,
+    "html": make_html,
+    "xml": make_xml,
+    "py": make_python,
+    "sh": make_bash,
+    "txt": make_text,
+    "ttf": make_ttf,
+    "sqlite": make_sqlite,
+    "js": make_js,
+    "c": make_c,
+}
+
+
+def add_exif_date(path, year, month):
+    if not shutil.which("exiftool"):
+        return False
+    day = random.randint(1, 28)
+    date_str = f"{year:04d}:{month:02d}:{day:02d} 12:00:00"
+    try:
+        subprocess.run(
+            ["exiftool", "-overwrite_original",
+             f"-DateTimeOriginal={date_str}",
+             f"-CreateDate={date_str}",
+             str(path)],
+            capture_output=True, timeout=5
+        )
+        return True
+    except Exception:
+        return False
+
+
+def set_mtime(path, year, month):
+    day = random.randint(1, 28)
+    timestamp = time.mktime((year, month, day, 12, 0, 0, 0, 0, 0))
+    os.utime(path, (timestamp, timestamp))
+
+
+def generate_test_data(output_dir, count=50, seed=None):
+    if seed is not None:
+        random.seed(seed)
+
+    root = Path(output_dir)
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+
+    generated = []
+    categories = list(GENERATORS.keys())
+
+    # Standard files
+    for i in range(count):
+        ext = random.choice(categories)
+        depth = random.randint(0, 4)
+        subdir = root
+        for d in range(depth):
+            subdir = subdir / f"subdir_{random.randint(0, 3)}"
+        subdir.mkdir(parents=True, exist_ok=True)
+
+        year = random.randint(2015, 2026)
+        month = random.randint(1, 12)
+
+        if random.random() < 0.1:
+            filename = f"tëst_fïle_{i}.{ext}"
+        elif random.random() < 0.1:
+            filename = f"file with spaces {i}.{ext}"
+        else:
+            filename = f"file_{i:04d}.{ext}"
+
+        filepath = subdir / filename
+        GENERATORS[ext](str(filepath))
+
+        if ext in ("jpg", "png", "gif") and random.random() < 0.5:
+            add_exif_date(filepath, year, month)
+        else:
+            set_mtime(filepath, year, month)
+
+        generated.append(filepath)
+
+    # Duplicates
+    dup_count = max(5, count // 10)
+    for i in range(dup_count):
+        if not generated:
+            break
+        source = random.choice(generated)
+        if not source.exists():
+            continue
+        ext = source.suffix.lstrip(".")
+        depth = random.randint(0, 3)
+        subdir = root
+        for d in range(depth):
+            subdir = subdir / f"dup_dir_{d}"
+        subdir.mkdir(parents=True, exist_ok=True)
+
+        if random.random() < 0.3:
+            dest = subdir / f"duplicate_{i}.{ext}"
+        elif random.random() < 0.5:
+            wrong_ext = random.choice(["txt", "bin", "dat"])
+            dest = subdir / f"wrong_ext_{i}.{wrong_ext}"
+        else:
+            dest = subdir / f"no_ext_{i}"
+
+        shutil.copy2(source, dest)
+        generated.append(dest)
+
+    # Edge cases
+    for i in range(3):
+        p = root / f"empty_{i}.txt"
+        make_empty(p)
+        generated.append(p)
+
+    p = root / "README"
+    make_text(str(p))
+    generated.append(p)
+
+    # tar.gz misnamed as .gz (issue #34)
+    p = root / "misnamed_as_gz.gz"
+    make_targz(str(p))
+    generated.append(p)
+
+    # Plain .gz named as .tar.gz (false positive)
+    p = root / "plain_gz_as_targz.tar.gz"
+    make_gz(str(p))
+    generated.append(p)
+
+    # Very long filename
+    p = root / ("x" * 200 + ".txt")
+    make_text(str(p))
+    generated.append(p)
+
+    # Special chars
+    for name in ["file(1).txt", "file&special.txt", "file+plus.txt"]:
+        p = root / name
+        make_text(str(p))
+        generated.append(p)
+
+    # Identical content, different extensions
+    shared_content = "name,age\nAlice,30\n"
+    for ext in ["txt", "csv"]:
+        p = root / f"shared_content.{ext}"
+        with open(p, "w") as f:
+            f.write(shared_content)
+        generated.append(p)
+
+    # 5 exact duplicate JPEGs
+    img_source = root / "canonical.jpg"
+    make_jpeg(str(img_source))
+    for i in range(5):
+        dest = root / "photos" / f"img_copy_{i}.jpg"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(img_source, dest)
+        generated.append(dest)
+
+    total = sum(1 for _ in root.rglob("*") if _.is_file())
+    print(f"Generated {total} files in {output_dir}")
+    return total
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate test data for organize_and_dedup.sh")
+    parser.add_argument("output_dir", help="Directory to generate test files in")
+    parser.add_argument("--count", type=int, default=50, help="Number of random files (default: 50)")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducibility")
+    args = parser.parse_args()
+    generate_test_data(args.output_dir, count=args.count, seed=args.seed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/organize_and_dedup.bats
+++ b/tests/organize_and_dedup.bats
@@ -1,0 +1,636 @@
+#!/usr/bin/env bats
+#
+# Test suite for organize_and_dedup.sh
+# Covers basic functionality and regression tests for issues #15-#52.
+#
+# Requirements: bats, file, sha256sum, stat, date (GNU coreutils)
+# Optional: exiftool (skipped if not installed)
+
+load test_helper
+
+setup() {
+    SCRIPT="$(abspath "$BATS_TEST_DIRNAME/../organize_and_dedup.sh")"
+    INPUT="$(mktemp -d)"
+    OUTPUT="$(mktemp -d)"
+    # Clean output so we start fresh
+    rm -rf "$OUTPUT"
+}
+
+teardown() {
+    rm -rf "$INPUT" "$OUTPUT"
+}
+
+# --- Basic functionality ---
+
+@test "--version prints version" {
+    run "$SCRIPT" --version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"organize_and_dedup.sh"* ]]
+}
+
+@test "--help prints usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    [[ "$output" == *"input_dir"* ]]
+    [[ "$output" == *"output_dir"* ]]
+}
+
+@test "no args exits with error" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+}
+
+@test "nonexistent input dir exits with error" {
+    run "$SCRIPT" /nonexistent/path "$OUTPUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"input directory does not exist"* ]]
+}
+
+@test "same input and output dir exits with error" {
+    run "$SCRIPT" "$INPUT" "$INPUT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be different"* ]]
+}
+
+@test "output path exists and is not a dir exits with error" {
+    local file="$INPUT/notadir"
+    touch "$file"
+    run "$SCRIPT" "$INPUT" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not a directory"* ]]
+}
+
+# --- File type detection ---
+
+@test "JPEG files are categorized as images" {
+    python3 "$BATS_TEST_DIRNAME/generate_test_data.py" "$INPUT" --count 0 --seed 1 2>/dev/null
+    # generate_test_data always adds edge cases; create a clean one
+    rm -rf "$INPUT"
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/images" -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "PNG files are categorized as images" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_png
+make_png('$INPUT/test.png')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/images" -name '*.png' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "PDF files are categorized as documents" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_pdf
+make_pdf('$INPUT/test.pdf')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/documents" -name '*.pdf' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "MP3 files are categorized as audio" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_mp3
+make_mp3('$INPUT/test.mp3')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/audio" -name '*.mp3' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "MP4 files are categorized as videos" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_mp4
+make_mp4('$INPUT/test.mp4')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/videos" -name '*.mp4' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "ZIP files are categorized as archives" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_zip
+make_zip('$INPUT/test.zip')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/archives" -name '*.zip' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "JSON files are categorized as text" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_json
+make_json('$INPUT/test.json')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/text" -name '*.json' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "Python files are categorized (issue #37: may be text or code depending on file magic)" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_python
+make_python('$INPUT/test.py')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # file --mime-type may return text/x-python, text/x-script.python, or text/plain
+    # depending on the magic database version. The script may classify it as
+    # code, text, or unknown. This test documents that the file is processed
+    # without error, regardless of classification.
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+@test "Bash scripts are categorized as code" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_bash
+make_bash('$INPUT/test.sh')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/code" -name '*.sh' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "SQLite databases are categorized as databases" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_sqlite
+make_sqlite('$INPUT/test.sqlite')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/databases" -name '*.sqlite' -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "TTF fonts are categorized as fonts" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_ttf
+make_ttf('$INPUT/test.ttf')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/fonts" -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+# --- Dedup ---
+
+@test "identical files are deduped (only first is linked)" {
+    mkdir -p "$INPUT/sub1" "$INPUT/sub2"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/sub1/original.jpg')
+"
+    cp "$INPUT/sub1/original.jpg" "$INPUT/sub2/copy.jpg"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # Should be exactly 1 file in output
+    [ "$(find "$OUTPUT" -type f | wc -l)" -eq 1 ]
+    [[ "$output" == *"Duplicate detected"* ]]
+}
+
+@test "5 identical JPEGs produce 1 output file" {
+    mkdir -p "$INPUT/photos"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/photos/canonical.jpg')
+"
+    for i in 1 2 3 4 5; do
+        cp "$INPUT/photos/canonical.jpg" "$INPUT/photos/copy_$i.jpg"
+    done
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/images" -type f | wc -l)" -eq 1 ]
+}
+
+@test "files with same content but different extensions: first wins" {
+    mkdir -p "$INPUT"
+    echo "name,age
+Alice,30" > "$INPUT/data.txt"
+    echo "name,age
+Alice,30" > "$INPUT/data.csv"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # First file processed wins; second is a duplicate
+    [[ "$output" == *"Duplicate detected"* ]]
+    [ "$(find "$OUTPUT/text" -type f | wc -l)" -eq 1 ]
+}
+
+# --- Edge cases ---
+
+@test "empty files are processed without error" {
+    mkdir -p "$INPUT"
+    touch "$INPUT/empty1.txt"
+    touch "$INPUT/empty2.txt"
+    touch "$INPUT/empty3.txt"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # All empty files have the same SHA-256, so only 1 output
+    [ "$(find "$OUTPUT" -type f | wc -l)" -eq 1 ]
+}
+
+@test "files with no extension are processed" {
+    mkdir -p "$INPUT"
+    echo "just text" > "$INPUT/README"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+@test "files with spaces in names are processed" {
+    mkdir -p "$INPUT"
+    echo "content" > "$INPUT/file with spaces.txt"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+@test "files with special characters are processed" {
+    mkdir -p "$INPUT"
+    echo "content" > "$INPUT/file(1).txt"
+    echo "content2 different" > "$INPUT/file&special.txt"
+    echo "content3 also different" > "$INPUT/file+plus.txt"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 3 ]
+}
+
+@test "Unicode filenames are processed" {
+    mkdir -p "$INPUT"
+    echo "unicode content here" > "$INPUT/tëst_fïle.txt"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+@test "very long filename is processed" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_text
+make_text('$INPUT/' + 'x'*200 + '.txt')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+@test "wrong extension file is classified by content not name" {
+    mkdir -p "$INPUT"
+    # A JPEG saved as .dat
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/photo.dat')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # Should be in images, not unknown
+    [ "$(find "$OUTPUT/images" -type f 2>/dev/null | wc -l)" -ge 1 ]
+}
+
+@test "nested directories are traversed" {
+    mkdir -p "$INPUT/a/b/c/d"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_png
+make_png('$INPUT/a/b/c/deep.png')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/images" -name '*.png' -type f | wc -l)" -ge 1 ]
+}
+
+# --- tar.gz detection (issue #34) ---
+
+@test "tar.gz file is detected (issue #34 - extension should be tar.gz or gz)" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_targz
+make_targz('$INPUT/archive.tar.gz')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # The file should be in archives
+    [ "$(find "$OUTPUT/archives" -type f | wc -l)" -ge 1 ]
+    # Issue #34: it should ideally be .tar.gz, but current code saves as .gz
+    # This test documents current behaviour — the extension is .gz (the bug)
+    local found_gz
+    found_gz=$(find "$OUTPUT/archives" -name '*.gz' -type f | wc -l)
+    [ "$found_gz" -ge 1 ]
+}
+
+@test "tar.gz misnamed as .gz is still detected as archive" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_targz
+make_targz('$INPUT/misnamed.gz')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/archives" -type f | wc -l)" -ge 1 ]
+}
+
+@test "plain .gz (not tar) is categorized as archive with .gz extension" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_gz
+make_gz('$INPUT/plain.gz')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT/archives" -name '*.gz' -type f | wc -l)" -ge 1 ]
+}
+
+# --- Output structure ---
+
+@test "output uses category/YYYY-MM/hash.ext structure" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # Check structure: images/YYYY-MM/hash.jpg
+    local files
+    files=$(find "$OUTPUT" -type f -name '*.jpg')
+    [ -n "$files" ]
+    # Path should match images/YYYY-MM/hash.jpg
+    [[ "$files" == *"/images/"* ]]
+    local parent
+    parent=$(dirname "$files")
+    [[ "$(basename "$parent")" =~ ^[0-9]{4}-[0-9]{2}$ ]]
+}
+
+@test "output filenames are SHA-256 hex (64 chars) with extension" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_png
+make_png('$INPUT/test.png')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    local file
+    file=$(find "$OUTPUT" -type f -name '*.png' | head -1)
+    [ -n "$file" ]
+    local basename
+    basename=$(basename "$file")
+    local hash_part
+    hash_part="${basename%%.*}"
+    # Should be 64 hex chars
+    [[ "$hash_part" =~ ^[0-9A-Fa-f]{64}$ ]]
+}
+
+# --- Re-run behaviour ---
+
+@test "re-run on same input produces no new files (all duplicates)" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg, make_png, make_pdf
+make_jpeg('$INPUT/a.jpg')
+make_png('$INPUT/b.png')
+make_pdf('$INPUT/c.pdf')
+"
+    # First run
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    local first_count
+    first_count=$(find "$OUTPUT" -type f | wc -l)
+
+    # Second run
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    local second_count
+    second_count=$(find "$OUTPUT" -type f | wc -l)
+
+    [ "$first_count" -eq "$second_count" ]
+    [[ "$output" == *"Duplicate detected"* ]]
+}
+
+# --- Summary output ---
+
+@test "summary line contains processed count" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Completed."* ]]
+    [[ "$output" == *"Processed:"* ]]
+    [[ "$output" == *"linked:"* ]]
+    [[ "$output" == *"duplicates:"* ]]
+}
+
+@test "summary shows 0 warnings on clean run" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"warnings: 0"* ]]
+}
+
+# --- Large dataset ---
+
+@test "generated test dataset (80 files) processes cleanly" {
+    python3 "$BATS_TEST_DIRNAME/generate_test_data.py" "$INPUT" --count 80 --seed 42 >/dev/null 2>&1
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Completed."* ]]
+    # Should have processed > 0 files
+    [[ "$output" == *"Processed: 1"* ]]  # 106+ files, starts with 1
+}
+
+# --- Hardlink verification ---
+
+@test "output files are hardlinks (same inode as source)" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    local outfile
+    outfile=$(find "$OUTPUT" -type f -name '*.jpg' | head -1)
+    [ -n "$outfile" ]
+    # Same filesystem — check inode matches
+    local in_inode out_inode
+    in_inode=$(stat -c '%i' "$INPUT/test.jpg")
+    out_inode=$(stat -c '%i' "$outfile")
+    [ "$in_inode" -eq "$out_inode" ]
+}
+
+# --- Issue-specific regression tests ---
+
+# Issue #15: skipped counter never incremented
+@test "issue #15: skipped counter is present in summary (may be 0)" {
+    mkdir -p "$INPUT"
+    echo "test" > "$INPUT/file.txt"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipped:"* ]]
+}
+
+# Issue #16: cleanup_on_interrupt exits 130 for SIGTERM (should be 143)
+# Skipped: SIGINT timing is unreliable in CI — the script may finish before
+# the signal arrives. The exit code issue is documented in the issue itself.
+@test "issue #16: cleanup_on_interrupt function exists and uses exit 130" {
+    # Verify the function is defined in the script
+    run grep -c 'cleanup_on_interrupt' "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" -ge 2 ]]  # defined + used in trap
+    run grep 'exit 130' "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+# Issue #22: CI should actually test bash
+# (This is tested by the existence of this test suite itself)
+
+# Issue #34: tar.gz saved as .gz
+@test "issue #34: tar.gz files end up in archives (current behaviour: .gz ext)" {
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_targz
+make_targz('$INPUT/real.tar.gz')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # Current behaviour: saved as .gz (the bug)
+    # Fix would save as .tar.gz
+    local gz_count
+    gz_count=$(find "$OUTPUT/archives" -name '*.gz' -type f | wc -l)
+    [ "$gz_count" -ge 1 ]
+    # Document: currently NO .tar.gz files are produced
+    local targz_count
+    targz_count=$(find "$OUTPUT/archives" -name '*.tar.gz' -type f | wc -l)
+    # This should be 0 with current code (the bug)
+    [ "$targz_count" -eq 0 ]
+}
+
+# Issue #35: all empty files dedup to one
+@test "issue #35: all empty files dedup to a single output entry" {
+    mkdir -p "$INPUT/dir1" "$INPUT/dir2" "$INPUT/dir3"
+    touch "$INPUT/dir1/empty.txt"
+    touch "$INPUT/dir2/empty.log"
+    touch "$INPUT/dir3/empty.dat"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # All empty files have same SHA-256 → 1 output
+    [ "$(find "$OUTPUT" -type f | wc -l)" -eq 1 ]
+}
+
+# Issue #37: code files misclassified as text/plain
+@test "issue #37: Python file is processed (classification depends on file magic version)" {
+    # file --mime-type may return text/x-python, text/x-script.python, or text/plain
+    # The script's case statement may not catch all variants → falls to bin unknown
+    # This test documents that the file IS processed without error.
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_python
+make_python('$INPUT/hello.py')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+# Issue #45: MIME type not lowercased
+@test "issue #45: file with uppercase MIME in magic db still processes" {
+    # This is a defensive test — most file versions return lowercase
+    # We just ensure processing doesn't crash on unusual MIME types
+    mkdir -p "$INPUT"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_text
+make_text('$INPUT/plain.txt')
+"
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    [ "$(find "$OUTPUT" -type f | wc -l)" -ge 1 ]
+}
+
+# Issue #48: pre-existing files not following naming convention
+@test "issue #48: pre-existing non-hash-named files in output are not deduped against" {
+    mkdir -p "$INPUT" "$OUTPUT/images/2026-01"
+    python3 -c "
+import sys; sys.path.insert(0, '$BATS_TEST_DIRNAME')
+from generate_test_data import make_jpeg
+make_jpeg('$INPUT/test.jpg')
+"
+    # Create a pre-existing file with a non-hash name
+    cp "$INPUT/test.jpg" "$OUTPUT/images/2026-01/my_photo.jpg"
+
+    run "$SCRIPT" "$INPUT" "$OUTPUT"
+    [ "$status" -eq 0 ]
+    # Current behaviour: the pre-existing file is NOT detected as a duplicate
+    # because it doesn't follow the <64hex>.<ext> naming convention.
+    # So the script will create a new hash-named file.
+    local hash_files
+    hash_files=$(find "$OUTPUT" -name '*.jpg' -regextype posix-extended -regex '.*/[0-9A-Fa-f]{64}\.jpg' | wc -l)
+    [ "$hash_files" -ge 1 ]
+}
+
+# Issue #22: no actual testing in CI
+@test "issue #22: this test suite exists (bash repo has bash tests)" {
+    # Meta test — if this runs, the test suite works
+    [ -f "$BATS_TEST_DIRNAME/organize_and_dedup.bats" ]
+    [ -f "$BATS_TEST_DIRNAME/test_helper.bash" ]
+    [ -f "$BATS_TEST_DIRNAME/generate_test_data.py" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Test helper for organize_and_dedup bats tests
+
+# Get absolute path of a file/directory
+abspath() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        (cd "$path" && pwd)
+    else
+        local dir base
+        dir=$(dirname "$path")
+        base=$(basename "$path")
+        echo "$(cd "$dir" && pwd)/$base"
+    fi
+}
+
+# Check if a command is available
+has_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Count files in a directory (recursive)
+count_files() {
+    find "$1" -type f 2>/dev/null | wc -l
+}
+
+# Count files matching a pattern
+count_files_matching() {
+    local dir="$1"
+    local pattern="$2"
+    find "$dir" -type f -name "$pattern" 2>/dev/null | wc -l
+}


### PR DESCRIPTION
## Summary

Adds a proper test framework for the bash script — something the repo has never had. This closes **issue #22** (CI checks for Node/Python but this is a bash repo with zero actual testing).

## What's included

### `tests/organize_and_dedup.bats` — 46 bats tests

| Category | Tests | Coverage |
|---|---|---|
| CLI | 6 | --version, --help, no args, bad input dir, same I/O dir, non-dir output |
| File type detection | 11 | JPEG, PNG, PDF, MP3, MP4, ZIP, JSON, Python, bash, SQLite, TTF |
| Dedup | 3 | Identical files, 5× JPEG copies, same-content-different-extension |
| Edge cases | 8 | Empty files, no extension, spaces, special chars `( ) & +`, Unicode, 200+ char filename, wrong extension → MIME detection, nested dirs |
| tar.gz detection | 3 | Real tar.gz, misnamed .gz, plain .gz false positive |
| Output structure | 2 | category/YYYY-MM/hash.ext layout, 64-char SHA-256 filenames |
| Re-run | 1 | Second run finds all duplicates, no new files |
| Summary | 2 | Completed line with counts, 0 warnings on clean run |
| Hardlink | 1 | Output file shares inode with source |
| Large dataset | 1 | 80-file generated dataset processes cleanly |
| Issue regressions | 8 | #15, #16, #22, #34, #35, #37, #45, #48 |

### `tests/generate_test_data.py` — realistic test data generator

Creates files with **valid MIME headers** so `file --mime-type` detects them correctly. This is critical — the script's entire logic depends on MIME detection, so test files must have proper magic bytes.

- 21 file types: JPEG, PNG, GIF, PDF, MP3, WAV, MP4, ZIP, tar.gz, gz, JSON, CSV, HTML, XML, Python, bash, JS, C, text, TTF, SQLite
- Duplicate files (same content, different names/extensions)
- Wrong extension files (`.dat` file that's actually a JPEG)
- No-extension, empty, Unicode, spaces, special chars
- tar.gz misnamed as .gz (issue #34), plain .gz as .tar.gz (false positive check)
- Random nesting (0-4 levels) and dates (2015-2026) via mtime + EXIF
- Seeded reproducibility (`--seed 42`)

### `.github/workflows/ci.yml` — real bash CI

Replaced the template CI that checked for `package.json` and `requirements.txt` (neither exists) with:
1. Install bats + exiftool
2. Verify required tools (file, sha256sum, stat, bats)
3. Run test data generator
4. Run `organize_and_dedup.sh` against generated data
5. Run `bats tests/`

## Test results

All 46 tests pass locally:
```
1..46
ok 1 --version prints version
ok 2 --help prints usage
...
ok 46 issue #22: this test suite exists (bash repo has bash tests)
```

## Design decisions

**Tests document current behaviour, including known bugs.** Several tests explicitly assert the *current (buggy) behaviour* so that when a fix lands, the test will fail and be updated — providing a clear before/after audit trail:

- **#34**: tar.gz files are saved with `.gz` extension (the bug). Test confirms this. A fix would change the test to expect `.tar.gz`.
- **#37**: Python files may be classified as `text/plain` or `text/x-script.python` depending on `file` magic version. Test is classification-agnostic — just verifies the file is processed.
- **#48**: Pre-existing files in output dir that don't follow `<64hex>.<ext>` naming are not deduped against. Test confirms a new hash-named file is created.
- **#15**: `skipped` counter is present in summary but always 0. Test verifies it appears.
- **#16**: `cleanup_on_interrupt` uses `exit 130` for both SIGINT and SIGTERM. Test verifies the function exists and uses exit 130.

## Related issues

Closes #22
References #15, #16, #34, #35, #37, #45, #48